### PR TITLE
refactor: support windows with trunk package

### DIFF
--- a/.aqua/aqua.yaml
+++ b/.aqua/aqua.yaml
@@ -7,12 +7,12 @@
 #   require_checksum: true
 registries:
   - type: standard
-    ref: v4.176.0 # renovate: depName=aquaproj/aqua-registry
+    ref: v4.184.0 # renovate: depName=aquaproj/aqua-registry
 packages:
-  - name: miniscruff/changie@v1.18.0
-  - name: goreleaser/goreleaser@v1.25.1
+  - name: miniscruff/changie@v1.19.0
+  - name: goreleaser/goreleaser@v1.26.1
   - name: magefile/mage@v1.15.0
-  - name: golangci/golangci-lint@v1.58.1
+  - name: golangci/golangci-lint@v1.58.2
   - name: golang/go@go1.22.3
   - name: gotestyourself/gotestsum@v1.11.0
   - name: BurntSushi/ripgrep@14.1.0

--- a/.changes/unreleased/🐛 Bug Fix-20240521-122813.yaml
+++ b/.changes/unreleased/🐛 Bug Fix-20240521-122813.yaml
@@ -1,0 +1,3 @@
+kind: "\U0001F41B Bug Fix"
+body: Trunk upgrade was set to install, not upgrade tooling, so now it does what it should have done in the first place... before the coder in question got in way and didn't use his noggin.
+time: 2024-05-21T12:28:13.507347-05:00

--- a/.changes/unreleased/🔨 Refactor-20240521-122929.yaml
+++ b/.changes/unreleased/🔨 Refactor-20240521-122929.yaml
@@ -1,0 +1,7 @@
+kind: "\U0001F528 Refactor"
+body: |-
+  Trunk package now supports installing for windows, via the newer trunk npm based install, while maintaining the bash install for linux/darwin.
+  If the project has a package.json, then it will install as dev dependency, otherwise as a global tool.
+  No logic to detect alternative tooling such as yarn, bun, deno, etc unless requested.
+  While trunk also supports this method of installation for Darwin/Linux, I've opted to keep it the same as before and use the bash install method for those regardless if package.json is there or not.
+time: 2024-05-21T12:29:29.380394-05:00

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,16 +56,15 @@ linters-settings:
         bson: camel
         avro: snake
         mapstructure: kebab
-    errcheck:
-      check-type-assertions: true
-      check-blank: false
-      ignore: fmt:.*,io/ioutil:^Read.*
-      exclude-functions:
-        - io/ioutil.ReadFile
-        - io.Copy(*bytes.Buffer)
-        - io.Copy(os.Stdout)
-        - io.Closer.Close
-        - io.Closer.Body.Close
+  errcheck:
+    check-type-assertions: true
+    check-blank: false
+    exclude-functions:
+      - io/ioutil.ReadFile
+      - io.Copy(*bytes.Buffer)
+      - io.Copy(os.Stdout)
+      - io.Closer.Close
+      - io.Closer.Body.Close
   govet:
     enable-all: true
     disable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -102,6 +102,9 @@ linters-settings:
     rules:
       - name: var-naming
         severity: error
+      - name: line-length-limit
+        arguments:
+          - 120
 
 linters:
   enable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,231 +1,147 @@
 ---
-# Any changes need to be carefully reviewed!
 output:
-  # colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions
-  # default is "colored-line-number"
-  # format: colored-line-number
-  # Compact format: tab
-  format: tab
+  formats:
+    - format: tab
 linters-settings:
   misspell:
     locale: US
-  gomnd:
-    settings:
-      mnd:
-        # the list of enabled checks, see https://github.com/tommy-muehle/go-mnd/#checks for description.
-        checks: [argument, case, condition, return]
-        ignored-functions: strconv.ParseFloat,rsa.GenerateKey
+
   nolintlint:
-    # Enable to ensure that nolint directives are all used. Default is true.
     allow-unused: false
-    # Disable to ensure that nolint directives don't have a leading space. Default is true.
-    allow-leading-space: true
-    # Exclude following linters from requiring an explanation.  Default is [].
     allow-no-explanation: []
-    # Enable to require an explanation of nonzero length after each nolint directive. Default is false.
     require-explanation: true
-    # Enable to require nolint directives to mention the specific linter being suppressed. Default is false.
     require-specific: true
   gofumpt:
-    # Select the Go version to target. The default is `1.15`.
-    lang-version: "1.18"
-
-    # Choose whether or not to use the extra rules that are disabled
-    # by default
     extra-rules: true
   godox:
-    # report any comments starting with keywords, this is useful for TODO or FIXME comments that
-    # might be left in the code accidentally and should be resolved before merging
-    keywords: # default keywords are TODO, BUG, and FIXME, these can be overwritten by this setting
-      - OPTIMIZE # marks code that should be optimized before merging
-      - HACK # marks hack-arounds that should be removed before merging
+    keywords:
+      - OPTIMIZE
+      - HACK
       - TODO
       - BUG
       - FIXME
-
   godot:
-    # comments to be checked: `declarations`, `toplevel`, or `all`
     scope: all
-    # list of regexps for excluding particular comment lines from check
     exclude:
       - //nolint
       - (API)
       - ^[ ]*@
-      # example: exclude comments which contain numbers
-      # - '[0-9]+'
-
-    # check that each sentence starts with a capital letter
     capital: true
+  depguard:
+    rules:
+      main:
+        deny:
+          - pkg: "github.com/sirupsen/logrus"
+            desc: use zerolog
+          - pkg: log
+            desc: use zerolog
+          - pkg: "github.com/pkg/errors"
+            desc: Should be replaced by standard lib errors package
 
-  wrapcheck:
-    ignorePackageGlobs:
-      - github.com/sheldonhull/magetools/*
-
-  # Configuration can be customized: https://github.com/ldez/tagliatelle
-  # This establishes consistency in the json naming, so that all json tagging uses the same approach.
+    # gomodguard:
+    #   blocked:
+    #     modules:
+    #       - github.com/sirupsen/logrus:
+    #           recommendations:
+    #             - internal/logging
+    #           reason: logging is allowed only by zerolog. Please use zerolog
+    #     local_replace_directives: false
   tagliatelle:
-    # check the struck tag name case
     case:
-      # use the struct field name to check the name of the struct tag
       use-field-name: true
       rules:
-        # any struct tag type can be used.
-        # support string case: `camel`, `pascal`, `kebab`, `snake`, `goCamel`, `goPascal`, `goKebab`, `goSnake`, `upper`, `lower`
-        json: goCamel
-        yaml: camel
+        json: snake
+        yaml: kebab
         xml: camel
         bson: camel
         avro: snake
         mapstructure: kebab
-
     errcheck:
-      # report about not checking of errors in type assertions: `a := b.(MyStruct)`;
-      # default is false: such cases aren't reported by default.
       check-type-assertions: true
-
-      # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
-      # default is false: such cases aren't reported by default.
       check-blank: false
-
-      # [deprecated] comma-separated list of pairs of the form pkg:regex
-      # the regex is used to ignore names within pkg. (default "fmt:.*").
-      # see https://github.com/kisielk/errcheck#the-deprecated-method for details
       ignore: fmt:.*,io/ioutil:^Read.*
-
-      # list of functions to exclude from checking, where each entry is a single function to exclude.
-      # see https://github.com/kisielk/errcheck#excluding-functions for details
       exclude-functions:
         - io/ioutil.ReadFile
         - io.Copy(*bytes.Buffer)
         - io.Copy(os.Stdout)
-        - io.Closer.Close #https://github.com/kisielk/errcheck/issues/132
+        - io.Closer.Close
         - io.Closer.Body.Close
-
-        # - (*net/http.Client).Do
-
   govet:
     enable-all: true
-    # report about shadowed variables
-    check-shadowing: true
     disable:
       - fieldalignment
-
-    # settings per analyzer
     settings:
-      printf: # analyzer name, run `go tool vet help` to see all analyzers
-        funcs: # run `go tool vet help printf` to see available settings for `printf` analyzer
+      printf:
+        funcs:
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
   varnamelen:
-    # The longest distance, in source lines, that is being considered a "small scope." (defaults to 5)
-    # Variables used in at most this many lines will be ignored.
-    max-distance: 15 # updated to 10 since we wrap struct and param lines pretty heavily
-    # The minimum length of a variable's name that is considered "long." (defaults to 3)
-    # Variable names that are at least this long will be ignored.
+    max-distance: 15
     min-name-length: 3
-    # Check method receiver names. (defaults to false)
     check-receiver: false
-    # Check named return values. (defaults to false)
     check-return: false
-    # Ignore "ok" variables that hold the bool return value of a type assertion. (defaults to false)
     ignore-type-assert-ok: true
-    # Ignore "ok" variables that hold the bool return value of a map index. (defaults to false)
     ignore-map-index-ok: true
-    # Ignore "ok" variables that hold the bool return value of a channel receive. (defaults to false)
     ignore-chan-recv-ok: true
-    # Optional list of variable names that should be ignored completely. (defaults to empty list)
     ignore-names:
       - err
       - tt
       - i
       - x
       - id
-      - b # for functions using byte input this is acceptable nomenclature
-      - ok # for functions doing checks on type assertions this is acceptable nomenclature
-      - zl # logger should be sure to keep brief
-      - fs # flagset, standard naming is acceptable.
-    # enable or disable analyzers by name
-    disable:
-      - fieldalignment # fieldalignment is not a priority except in high performance scenarios, and is a form of premature optimization
+      - b
+      - ok
+      - zl
+      - fs
+
   revive:
-    # see https://github.com/mgechev/revive#available-rules for details.
     ignore-generated-header: true
-    enableAllRules: true
-    exclude:
-      - .*_test.go
-    #    severity: warning
-    #    rules:
+    enable-all-rules: true
     rules:
       - name: var-naming
         severity: error
-        #arguments:
 
-#      - name: indent-error-flow
-#        severity: warning
-#      - name: add-constant
-#        severity: warning
-#        arguments:
-#          - maxLitCount: '3'
-#            allowStrs: '""'
-#            allowInts: '0,1,2'
-#            allowFloats: '0.0,0.,1.0,1.,2.0,2.'
 linters:
-  # disable-all: true
-  # enable:
-  #   - megacheck
-  #   - govet
-  exclude-use-default: false # Some key checks that will be missing if the default of 'true' is kept. (comments on exported and other will be missing!)
-  enable-all: true # disabling to provide control on mage and project tooling. pass --enable-all on the cli calls to run all.
+  enable-all: true
   disable:
     - scopelint
     - paralleltest
-    # - staticcheck
     - noctx
     - wsl
     - lll
     - interfacer
-    - golint # The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive.
+    - golint
     - maligned
-    - goimports # causes whiplash with gofumpt
+    - goimports
     - gci
     - gofmt
-    - nlreturn # until it supports autofix, just ignore as too much manual work
+    - nlreturn
     - gofumpt
     - exhaustivestruct
-    - exhaustruct # replaced exhaustivestruct by https://github.com/golangci/golangci-lint/pull/2667, v1.46.0.
+    - exhaustruct
     - wrapcheck
     - godox
-    - execinquery # Causes error in mtservice by https://github.com/golangci/golangci-lint/issues/2835, v1.46.0. Should remove from here after the bug is fixed.
-    - nonamedreturns # Added by https://github.com/golangci/golangci-lint/pull/2701, v1.46.0. Named returns are useful for defer. May remove from here and use nolint in future task.
-    - forbidigo # Disabled 2022-07-22 until migrating to a structured logger package. FMT is allowed for now
-    - structcheck # abandoned
-    - varcheck # abandoned
-    - deadcode # abandoned
-    - ifshort # abandoned
-    - godox # for periods
-    - godot # stop bugging me
-    - nosnakecase # not active anymore
-    - depguard
-    - perfsprint # seems like much premature optimization for things not running in high concurrency or scale
-# VSCode sets golangci-lint fast flag to avoid IDE issues in this project.
-# Disabled and instead scoping lint on save to current package.
-# To check everything run command Lint: Workspace
-# fast: false
+    - execinquery
+    - nonamedreturns
+    - forbidigo
+    - structcheck
+    - varcheck
+    - deadcode
+    - ifshort
+    - godox
+    - godot
+    - nosnakecase
+    - rowserrcheck # disabled due to generics, can enable in future if needed
+    - sqlclosecheck # disabled due to generics, can enable in future if needed
+    - wastedassign # disabled due to generics, can enable in future if needed
+    - funlen #OVERRIDE: ok using for bot, lots of quick long commands i worked on
+    - cyclop #OVERRIDE: ok using for bot, lots of quick long commands i worked on
+    - gocognit #OVERRIDE: ok using for bot, lots of quick long commands i worked on
+
 run:
-  # Fix found issues (if it's supported by the linter)
-  # fix: true
-  # skip-dirs-use-default: true # Enables skipping of directories:
-  # - vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
-  skip-dirs-use-default: true
-  skip-dirs:
-    - build
-    - artifacts
-    - _tools
-    - vendor
-    - vendor$
-  # lint magefile, but ignore tools.go
+  timeout: 5m
   build-tags:
     - mage
     - tools
@@ -237,42 +153,55 @@ issues:
       linters:
         - goerr113
         - wrapcheck
-        - funlen # complexity length in tests isn't a big concern
-        - cyclop # complexity length in tests isn't a big concern
-        - gocognit # complexity length in tests isn't a big concern
-        - unparam # unused params in tests isn't as important
-        - varnamelen # don't worry about variable name length in test code (nice to keep clean, but not important enough to speed time on)
-        - revive # additional checks like constants and more aren't important in the test code
+        - funlen
+        - cyclop
+        - gocognit
+        - unparam
+        - varnamelen
+        - revive
     - linters:
         - goerr113
       text: do not define dynamic errors
-    - path: magefiles/
+    - path: magefiles
       linters:
         - goerr113
         - wrapcheck
-        - funlen # a lot of these are a longer automation tasks and not worth breaking down
-        - gocyclo # a lot of these are a longer automation tasks and not worth breaking down
-        - cyclop # a lot of these are a longer automation tasks and not worth breaking down
-        - gocognit # a lot of these are a longer automation tasks and not worth breaking down
-        - maintidx # a lot of these are a longer automation tasks and not worth breaking down
-        - deadcode # not appliable to standalone tasks
-        - perfsprint # performance on basic output of mage is not something to be concerned about
+        - funlen
+        - gocyclo
+        - cyclop
+        - gocognit
+        - maintidx
+        - deadcode
+        - gochecknoglobals
+    - path: magefile.go
+      linters:
+        - goerr113
+        - wrapcheck
+        - funlen
+        - gocyclo
+        - cyclop
+        - gocognit
+        - maintidx
+        - deadcode
+        - gochecknoglobals
     - linters:
         - goerr113
       text: magefiles don't need to worry about wrapping in the same way
     - linters:
         - govet
         - revive
-      text: "shadow: declaration of .err. shadows declaration" # err shadowing is a normal practice, don't worry about this
+      text: "shadow: declaration of .err. shadows declaration"
     - path: mocks
       linters:
         - godot
       text: mocked files do not need to be checked
-
-    # - linters:
-    #     - revive
-    #   text: 'add-constant: avoid magic numbers like ''(\d*)'', create a named constant for it'
-
-  # Show only new issues created after git revision `REV`
-  whole-files: false # Only evaluate the sections of changed code rather than the entire file
-  # ONLY REQUIRED FOR OLD PROJECTS, NEW SHOULD COVER ALL ISSUES: new-from-rev: HEAD~
+  whole-files: false
+  exclude-dirs:
+    - build
+    - .artifacts
+    - .cache
+    - artifacts
+    - .trunk
+    - _tools
+    - vendor
+    - vendor$

--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -2,6 +2,8 @@
 *logs
 *actions
 *notifications
+*tools
 plugins
 user_trunk.yaml
 user.yaml
+tmp

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,10 +1,10 @@
 version: 0.1
 cli:
-  version: 1.10.0
+  version: 1.22.1
 plugins:
   sources:
     - id: trunk
-      ref: v0.0.17
+      ref: v1.5.0
       uri: https://github.com/trunk-io/plugins
 actions:
   enabled:
@@ -15,26 +15,31 @@ actions:
     - trunk-upgrade-available
 runtimes:
   enabled:
-    - go@1.20.4
+    - go@1.21.0
     - node@18.12.1
     - python@3.10.8
 lint:
   disabled:
+    - checkov
     - cspell
   enabled:
-    - actionlint@1.6.24
+    - osv-scanner@1.7.3
+    - trivy@0.51.2
+    - trufflehog@3.76.3
+    - renovate@37.369.1
+    - actionlint@1.7.0
     - dotenv-linter@3.3.0
     - git-diff-check
-    - gitleaks@8.16.2
-    - gofmt@1.19.3
-    - golangci-lint@1.52.1
+    - gitleaks@8.18.2
+    - gofmt@1.20.4
+    - golangci-lint@1.57.2
     - hadolint@2.12.0
-    - markdownlint@0.33.0
-    - prettier@2.8.7
-    - shellcheck@0.9.0
-    - shfmt@3.5.0
-    - taplo@0.8.0
-    - yamllint@1.30.0
+    - markdownlint@0.40.0
+    - prettier@3.2.5
+    - shellcheck@0.10.0
+    - shfmt@3.6.0
+    - taplo@0.8.1
+    - yamllint@1.35.1
   ignore:
     - linters: [ALL]
       paths:

--- a/trunk/trunk_unix.go
+++ b/trunk/trunk_unix.go
@@ -1,11 +1,11 @@
+// go:build linux darwin
+
 // Package trunk contains tasks to automate setup and usage in Mage based projects for the great trunk.io tooling.
 package trunk
 
 import (
-	"errors"
 	"os"
 	"os/exec"
-	"runtime"
 
 	"github.com/bitfield/script"
 	"github.com/magefile/mage/mg"
@@ -25,23 +25,10 @@ func (Trunk) Init() {
 	)
 }
 
-// checkCompatibility checks the current OS and warns if trunk.io is not supported with an error that can be either bypassed or handled.
-func checkCompatibility() error {
-	magetoolsutils.CheckPtermDebug()
-	if runtime.GOOS == "windows" {
-		pterm.Warning.Printfln("trunk.io is not supported on: %s", runtime.GOOS)
-		return errors.New("trunk.io is not supported on: " + runtime.GOOS)
-	}
-	return nil
-}
-
 // ⚙️ InstallTrunk installs trunk.io tooling if it isn't already found.
 func (Trunk) Install() error {
 	magetoolsutils.CheckPtermDebug()
-	if err := checkCompatibility(); err != nil {
-		pterm.Warning.Printfln("[non-terminating] skipping trunk.io installation due to incompatible OS: %v", err)
-		return nil
-	}
+
 	_, err := exec.LookPath("trunk")
 	if err != nil && os.IsNotExist(err) {
 		pterm.Warning.Printfln("unable to resolve aqua cli tool, please install for automated project tooling setup: https://aquaproj.github.io/docs/tutorial-basics/quick-start#install-aqua")
@@ -57,18 +44,10 @@ func (Trunk) Install() error {
 
 // ⚙️ InstallPlugins ensures the required runtimes are installed.
 func (Trunk) InstallPlugins() error {
-	if err := checkCompatibility(); err != nil {
-		pterm.Warning.Printfln("[non-terminating] skipping trunk.io installation due to incompatible OS: %v", err)
-		return nil
-	}
 	return sh.RunV("trunk", "install")
 }
 
 // ⚙️ Upgrade upgrades trunk using itself and also the plugins.
 func (Trunk) Upgrade() error {
-	if err := checkCompatibility(); err != nil {
-		pterm.Warning.Printfln("[non-terminating] skipping trunk.io installation due to incompatible OS: %v", err)
-		return nil
-	}
-	return sh.RunV("trunk", "install")
+	return sh.RunV("trunk", "upgrade")
 }

--- a/trunk/trunk_unix.go
+++ b/trunk/trunk_unix.go
@@ -11,6 +11,7 @@ import (
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
 	"github.com/pterm/pterm"
+	"github.com/sheldonhull/magetools/ci"
 	"github.com/sheldonhull/magetools/pkg/magetoolsutils"
 )
 
@@ -19,6 +20,8 @@ type Trunk mg.Namespace
 
 // ⚙️ Init installs trunk and ensures the plugins are setup.
 func (Trunk) Init() {
+	magetoolsutils.CheckPtermDebug()
+	pterm.DefaultSection.Println("(Trunk) Init")
 	mg.SerialDeps(
 		Trunk{}.Install,
 		Trunk{}.InstallPlugins,
@@ -28,6 +31,7 @@ func (Trunk) Init() {
 // ⚙️ InstallTrunk installs trunk.io tooling if it isn't already found.
 func (Trunk) Install() error {
 	magetoolsutils.CheckPtermDebug()
+	pterm.DefaultSection.Println("(Trunk) Install")
 
 	_, err := exec.LookPath("trunk")
 	if err != nil && os.IsNotExist(err) {
@@ -44,10 +48,26 @@ func (Trunk) Install() error {
 
 // ⚙️ InstallPlugins ensures the required runtimes are installed.
 func (Trunk) InstallPlugins() error {
-	return sh.RunV("trunk", "install")
+	magetoolsutils.CheckPtermDebug()
+	pterm.DefaultSection.Println("(Trunk) InstallPlugins")
+	trunkArgs := []string{
+		"install",
+	}
+	if ci.IsCI() {
+		trunkArgs = append(trunkArgs, "--ci")
+	}
+	return sh.RunV("trunk", trunkArgs...)
 }
 
 // ⚙️ Upgrade upgrades trunk using itself and also the plugins.
 func (Trunk) Upgrade() error {
-	return sh.RunV("trunk", "upgrade")
+	magetoolsutils.CheckPtermDebug()
+	pterm.DefaultSection.Println("(Trunk) Upgrade")
+	trunkArgs := []string{
+		"upgrade",
+	}
+	if ci.IsCI() {
+		trunkArgs = append(trunkArgs, "--ci")
+	}
+	return sh.RunV("trunk", trunkArgs...)
 }

--- a/trunk/trunk_windows.go
+++ b/trunk/trunk_windows.go
@@ -11,6 +11,7 @@ import (
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
 	"github.com/pterm/pterm"
+	"github.com/sheldonhull/magetools/ci"
 	"github.com/sheldonhull/magetools/pkg/magetoolsutils"
 )
 
@@ -19,6 +20,7 @@ type Trunk mg.Namespace
 
 // ⚙️ Init installs trunk and ensures the plugins are setup.
 func (Trunk) Init() {
+	pterm.DefaultSection.Println("(Trunk) Init")
 	mg.SerialDeps(
 		Trunk{}.Install,
 		Trunk{}.InstallPlugins,
@@ -28,6 +30,7 @@ func (Trunk) Init() {
 // ⚙️ InstallTrunk installs trunk.io tooling if it isn't already found.
 func (Trunk) Install() error {
 	magetoolsutils.CheckPtermDebug()
+	pterm.DefaultSection.Println("(Trunk) Install")
 	prefixPath()
 	// if there's a package.json then use npm install with npm install -D @trunkio/launcher, else install as a global tool
 	_, err := exec.LookPath("trunk")
@@ -54,6 +57,7 @@ func (Trunk) Install() error {
 
 // prefixPath checks for trunk installed as a dev dependency, and if so, prepends the node modules bin/trunk path to the PATH so it can be referenced without npm in front.
 func prefixPath() {
+	magetoolsutils.CheckPtermDebug()
 	if _, err := os.Stat("node_modules/.bin/trunk"); err == nil {
 		pterm.Debug.Printfln("Found trunk.io installed as a dev dependency, prefixing PATH")
 		os.Setenv("PATH", "node_modules/.bin"+string(os.PathListSeparator)+os.Getenv("PATH"))
@@ -62,12 +66,28 @@ func prefixPath() {
 
 // ⚙️ InstallPlugins ensures the required runtimes are installed.
 func (Trunk) InstallPlugins() error {
+	magetoolsutils.CheckPtermDebug()
+	pterm.DefaultSection.Println("(Trunk) InstallPlugins")
 	prefixPath()
-	return sh.RunV("trunk", "install")
+	trunkArgs := []string{
+		"install",
+	}
+	if ci.IsCI() {
+		trunkArgs = append(trunkArgs, "--ci")
+	}
+	return sh.RunV("trunk", trunkArgs...)
 }
 
 // ⚙️ Upgrade upgrades trunk using itself and also the plugins.
 func (Trunk) Upgrade() error {
+	magetoolsutils.CheckPtermDebug()
+	pterm.DefaultSection.Println("(Trunk) Upgrade")
 	prefixPath()
-	return sh.RunV("trunk", "upgrade")
+	trunkArgs := []string{
+		"upgrade",
+	}
+	if ci.IsCI() {
+		trunkArgs = append(trunkArgs, "--ci")
+	}
+	return sh.RunV("trunk", trunkArgs...)
 }

--- a/trunk/trunk_windows.go
+++ b/trunk/trunk_windows.go
@@ -1,0 +1,73 @@
+// go:build windows
+
+// Package trunk contains tasks to automate setup and usage in Mage based projects for the great trunk.io tooling.
+package trunk
+
+import (
+	"os"
+	"os/exec"
+
+	"github.com/bitfield/script"
+	"github.com/magefile/mage/mg"
+	"github.com/magefile/mage/sh"
+	"github.com/pterm/pterm"
+	"github.com/sheldonhull/magetools/pkg/magetoolsutils"
+)
+
+// ⚙️ Trunk contains tasks related to Trunk.io tooling.
+type Trunk mg.Namespace
+
+// ⚙️ Init installs trunk and ensures the plugins are setup.
+func (Trunk) Init() {
+	mg.SerialDeps(
+		Trunk{}.Install,
+		Trunk{}.InstallPlugins,
+	)
+}
+
+// ⚙️ InstallTrunk installs trunk.io tooling if it isn't already found.
+func (Trunk) Install() error {
+	magetoolsutils.CheckPtermDebug()
+	prefixPath()
+	// if there's a package.json then use npm install with npm install -D @trunkio/launcher, else install as a global tool
+	_, err := exec.LookPath("trunk")
+	if err != nil && os.IsNotExist(err) {
+		if _, err := os.Stat("package.json"); err == nil {
+			pterm.Info.Printfln("Found package.json, installing trunk.io as a dev dependency")
+			_, err := script.Exec("npm install -D @trunkio/launcher").Stdout()
+			if err != nil {
+				return err
+			}
+		} else {
+			pterm.Info.Printfln("No package.json found, installing trunk.io globally")
+			_, err := script.Exec("npm install -g @trunkio/launcher").Stdout()
+			if err != nil {
+				return err
+			}
+		}
+	} else {
+		pterm.Success.Printfln("trunk.io already installed, skipping")
+	}
+
+	return nil
+}
+
+// prefixPath checks for trunk installed as a dev dependency, and if so, prepends the node modules bin/trunk path to the PATH so it can be referenced without npm in front.
+func prefixPath() {
+	if _, err := os.Stat("node_modules/.bin/trunk"); err == nil {
+		pterm.Debug.Printfln("Found trunk.io installed as a dev dependency, prefixing PATH")
+		os.Setenv("PATH", "node_modules/.bin"+string(os.PathListSeparator)+os.Getenv("PATH"))
+	}
+}
+
+// ⚙️ InstallPlugins ensures the required runtimes are installed.
+func (Trunk) InstallPlugins() error {
+	prefixPath()
+	return sh.RunV("trunk", "install")
+}
+
+// ⚙️ Upgrade upgrades trunk using itself and also the plugins.
+func (Trunk) Upgrade() error {
+	prefixPath()
+	return sh.RunV("trunk", "upgrade")
+}


### PR DESCRIPTION
- Support windows with npm install method now available on trunk.
- Support detection of package.json for devdependency style install on windows vs global tool, and the required path updates for this.
- Fix upgrade not being an upgrade command, whoops.

No test coverage this for as involves an external tool and not worth testing outside of regular usage.